### PR TITLE
Fix "Cannot find module for ..." on Windows

### DIFF
--- a/auto_type_annotate.py
+++ b/auto_type_annotate.py
@@ -32,7 +32,11 @@ def _to_mod(fname: str, roots: tuple[str, ...]) -> str:
     relpaths.sort(key=len)
     for relative in relpaths:
         assert not relative.startswith('..'), relative  # report a bug?
-        return relative.removesuffix('.py').replace('/', '.')
+        return (
+            relative.removesuffix('.py')
+            .replace('/', '.')
+            .replace('\\', '.')
+        )
     else:
         raise AssertionError(f'{fname=} not found in {roots=}')
 

--- a/tests/auto_type_annotate_test.py
+++ b/tests/auto_type_annotate_test.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import ast
 import contextlib
+import ntpath
+import os
 import subprocess
 import sys
+from unittest.mock import patch
 
 from auto_type_annotate import _add_imports
 from auto_type_annotate import _rewrite_src
@@ -20,6 +23,11 @@ _MOD = Mod('t.py', 't')
 def test_to_mod_uses_longest_path():
     assert _to_mod('a/b/c.py', ('.', 'a')) == 'b.c'
     assert _to_mod('a/b/c.py', ('a', '.')) == 'b.c'
+
+
+@patch.object(os.path, 'relpath', new=ntpath.relpath)
+def test_to_mod_uses_longest_path_windows():
+    assert _to_mod(r'a\b\c.py', ('.', 'a')) == 'b.c'
 
 
 def test_to_mod_src_layout():


### PR DESCRIPTION
Thanks a lot for this project, it looks very promising! 

This pull request fixes a bug where the following message is issued for all the files that are processed:

```
Cannot find module for foo\bar.module
skipping module...
```

This was due to an invalid generation of the module names, that still contained `\` characters (`foo\bar` instead of `foo.bar`).

As a result, `test_to_mod_uses_longest_path` failed on Windows with the following output:

```
def test_to_mod_uses_longest_path():
>       assert _to_mod('a/b/c.py', ('.', 'a')) == 'b.c'
E       AssertionError: assert 'b\\c' == 'b.c'
E         
E         - b.c
E         + b\c
```