### PR TITLE
fix annotating __init__.py files by stripping __init__ from modpath

### DIFF
--- a/auto_type_annotate.py
+++ b/auto_type_annotate.py
@@ -36,6 +36,7 @@ def _to_mod(fname: str, roots: tuple[str, ...]) -> str:
             relative.removesuffix('.py')
             .replace('/', '.')
             .replace('\\', '.')
+            .replace(".__init__", "")
         )
     else:
         raise AssertionError(f'{fname=} not found in {roots=}')

--- a/tests/auto_type_annotate_test.py
+++ b/tests/auto_type_annotate_test.py
@@ -34,6 +34,9 @@ def test_to_mod_src_layout():
     assert _to_mod('src/foo.py', ('.', 'src')) == 'foo'
     assert _to_mod('bar.py', ('.', 'src')) == 'bar'
 
+def test_to_mod_init_files():
+    assert _to_mod('a/__init__.py', ('.',)) == 'a'
+
 
 def _find_untyped(s):
     visitor = FindUntyped()


### PR DESCRIPTION
Mypy doesn't like `__init__` in path names.

```
dmypy suggest a.__ini__.foo
Unknown class a.__ini__
```

 Stripping them out of the modpath gets `__init__.py` files to be annotated like other files. Couldn't get it to work for `__main__.py` files though.

```
dmypy suggest a.foo
() -> None
```