### PR TITLE
ci(release): Switch from action-prepare-release to Craft

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,0 +1,13 @@
+name: Changelog Preview
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - edited
+    - labeled
+jobs:
+  changelog-preview:
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    secrets: inherit

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -7,6 +7,10 @@ on:
     - reopened
     - edited
     - labeled
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -7,6 +7,7 @@ on:
     - reopened
     - edited
     - labeled
+    - unlabeled
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,6 @@ on:
     tags: '*'
   pull_request:
 
-
-permissions:
-  contents: write
-  pull-requests: write
 jobs:
   tox:
     runs-on: ubuntu-latest
@@ -19,7 +15,7 @@ jobs:
         - {env: py311, python: '3.11'}
         - {env: py313, python: '3.13'}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
@@ -29,7 +25,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
@@ -38,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         - {env: py311, python: '3.11'}
         - {env: py313, python: '3.13'}
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
@@ -29,7 +29,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
@@ -38,7 +38,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         - {env: py311, python: '3.11'}
         - {env: py313, python: '3.13'}
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
@@ -25,7 +25,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     tags: '*'
   pull_request:
 
+
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   tox:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         - {env: py311, python: '3.11'}
         - {env: py313, python: '3.13'}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
@@ -25,7 +25,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         - {env: py311, python: '3.11'}
         - {env: py313, python: '3.13'}
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
@@ -25,7 +25,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,23 @@ on:
         required: false
 jobs:
   release:
-    uses: getsentry/craft/.github/workflows/release.yml@v2
-    with:
-      version: ${{ inputs.version }}
-      force: ${{ inputs.force }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    name: Release a new version
+    steps:
+    - name: Get auth token
+      id: token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ steps.token.outputs.token }}
+        fetch-depth: 0
+    - name: Prepare release
+      uses: getsentry/craft@v2
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+      with:
+        version: ${{ inputs.version }}
+        force: ${{ inputs.force }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       force:
         description: Force a release even when there are release-blockers
         required: false
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,16 +19,16 @@ jobs:
     steps:
     - name: Get auth token
       id: token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v2
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
     - name: Prepare release
-      uses: getsentry/craft@v2
+      uses: getsentry/craft@39ee616a6a58dc64797feecb145d66770492b66c # v2
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
     - name: Prepare release
-      uses: getsentry/craft@39ee616a6a58dc64797feecb145d66770492b66c # v2
+      uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
+        uses: getsentry/craft@c6e2f04939b6ee67030588afbb5af76b127d8203 # v2
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3 # v2
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
     - name: Get auth token
       id: token
-      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v2
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3 # v3 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3 # v3 # v2
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,8 +7,9 @@ on:
         description: Version to release (or "auto")
         required: false
       force:
-        description: Force a release even when there are release-blockers
+        description: Force a release even when there are release-blockers (optional)
         required: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -15,22 +17,22 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: Release a new version
+    name: "Release a new version"
     steps:
-    - name: Get auth token
-      id: token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
-      with:
-        app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-        private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
-      with:
-        token: ${{ steps.token.outputs.token }}
-        fetch-depth: 0
-    - name: Prepare release
-      uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
-      env:
-        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-      with:
-        version: ${{ inputs.version }}
-        force: ${{ inputs.force }}
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+      - name: Prepare release
+        uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,17 @@
 name: Release
-
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release
-        required: true
-      force:
-        description: Force a release even when there are release-blockers (optional)
+        description: Version to release (or "auto")
         required: false
-
+      force:
+        description: Force a release even when there are release-blockers
+        required: false
 jobs:
   release:
-    runs-on: ubuntu-latest
-    name: "Release a new version"
-    steps:
-      - name: Get auth token
-        id: token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        with:
-          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ steps.token.outputs.token }}
-          fetch-depth: 0
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
-        env:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
+    uses: getsentry/craft/.github/workflows/release.yml@v2
+    with:
+      version: ${{ inputs.version }}
+      force: ${{ inputs.force }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

This PR migrates from the deprecated `action-prepare-release` to the new Craft GitHub Actions.

## Changes

- Migrated `.github/workflows/release.yml` to Craft reusable workflow

## Documentation

See https://getsentry.github.io/craft/github-actions/ for more information.
